### PR TITLE
Add simple HTML validation test and workflow

### DIFF
--- a/.github/workflows/html-validation.yml
+++ b/.github/workflows/html-validation.yml
@@ -1,0 +1,25 @@
+name: HTML validation
+
+on:
+  push:
+    paths:
+      - 'index.html'
+      - 'validate-html.js'
+      - 'package.json'
+      - '.github/workflows/html-validation.yml'
+  pull_request:
+    paths:
+      - 'index.html'
+      - 'validate-html.js'
+      - 'package.json'
+      - '.github/workflows/html-validation.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "electrohotermshop",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node validate-html.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/validate-html.js
+++ b/validate-html.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const html = fs.readFileSync('index.html', 'utf8');
+let errors = [];
+const trimmed = html.trim();
+if (!/^<!DOCTYPE html>/i.test(trimmed)) {
+  errors.push('Missing or incorrect DOCTYPE.');
+}
+if (!/<html[^>]*>/i.test(html)) {
+  errors.push('Missing opening <html> tag.');
+}
+if (!/<\/html>\s*$/i.test(trimmed)) {
+  errors.push('Missing closing </html> tag.');
+}
+if (!/<head>[\s\S]*<\/head>/i.test(html)) {
+  errors.push('Missing <head>...</head> section.');
+}
+if (errors.length) {
+  console.error('Validation errors found:');
+  for (const err of errors) {
+    console.error('- ' + err);
+  }
+  process.exit(1);
+} else {
+  console.log('index.html passed basic validation.');
+}


### PR DESCRIPTION
## Summary
- add npm project metadata
- create a basic `validate-html.js` script
- run `npm test` via GitHub Actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f652b1254832b8d1f6aad75adb71d